### PR TITLE
Remove type instabilities and allocations (~20x speedup)

### DIFF
--- a/src/vegas.jl
+++ b/src/vegas.jl
@@ -271,3 +271,4 @@ function sample_from_adaptive_grid(res, ncalls)
 	end
 	map(x -> tuple(x...), eachcol(xmat))
 end
+


### PR DESCRIPTION
For the following code I get a 20x speedup with the changes in this PR

```julia
using MonteCarloIntegration
f2(x) = x[1]^2 + x[2]^2 < 1
@time vegas(f2, -ones(2), ones(2), ncalls=1000000).integral_estimate

```